### PR TITLE
Fix clear chat persistence and background color issues

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -47,6 +47,7 @@ export const ChatInterface = ({ onMoodChange }: ChatInterfaceProps) => {
   const addMessage = useAddChatMessage();
   const addMood = useAddMoodEntry();
   const clearChat = useClearChat();
+  const [clearCutoff, setClearCutoff] = useState<Date | null>(null);
 
   useEffect(() => {
     if (history) {

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -69,7 +69,6 @@ export const ChatInterface = ({ onMoodChange }: ChatInterfaceProps) => {
   }, [history, clearCutoff]);
 
   const [isGenerating, setIsGenerating] = useState(false);
-  const [clearCutoff, setClearCutoff] = useState<Date | null>(null);
 
   const callAI = async (history: Message[], mood?: Mood) => {
     try {

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -61,7 +61,7 @@ export const MainLayout = () => {
   };
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className="flex h-screen">
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
       <main className="flex-1 overflow-auto">
         {renderContent()}

--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -64,9 +64,9 @@ export function useClearChat() {
       return { previous } as { previous: unknown };
     },
     onError: () => {
-      // Keep cache cleared to avoid UI restoring old messages on navigation
+      // Do not refetch on error. Keep cache cleared to avoid restoring old messages.
     },
-    onSettled: () => {
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["chat_messages"] });
     },
   });


### PR DESCRIPTION
## Purpose

Users reported two critical issues:
1. Clear chat functionality not working properly - old chat messages were reappearing after clearing
2. Background color change feature not functioning as expected

This PR addresses both issues to improve the user experience with chat management and UI customization.

## Code Changes

**Chat Interface (`ChatInterface.tsx`)**:
- Added `clearCutoff` state to track when chat was cleared
- Modified message filtering logic to exclude messages before the clear cutoff timestamp
- Updated `handleClearChat` to set cutoff timestamp before clearing
- Enhanced dependency array to include `clearCutoff` for proper re-rendering

**Main Layout (`MainLayout.tsx`)**:
- Removed hardcoded `bg-background` class to allow dynamic background color changes

**Data Hooks (`useSupabaseData.ts`)**:
- Changed `onSettled` to `onSuccess` to only invalidate queries on successful clear operations
- Updated error handling comments for clarityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/87710a066f1544568656bf3de19e1e52/swoosh-space)

👀 [Preview Link](https://87710a066f1544568656bf3de19e1e52-swoosh-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>87710a066f1544568656bf3de19e1e52</projectId>-->
<!--<branchName>swoosh-space</branchName>-->