### PR TITLE
Fix chat clear persistence across sessions and tabs

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -230,6 +230,10 @@ export const ChatInterface = ({ onMoodChange }: ChatInterfaceProps) => {
     setClearCutoff(now);
     if (cutoffKey) {
       localStorage.setItem(cutoffKey, now.toISOString());
+    } else {
+      const { data } = await supabase.auth.getUser();
+      const key = data.user?.id ? `chatClearCutoff:${data.user.id}` : null;
+      if (key) localStorage.setItem(key, now.toISOString());
     }
     try {
       await clearChat.mutateAsync();


### PR DESCRIPTION
## Purpose

The user reported an issue where old chat messages were reappearing after clearing the chat, particularly when switching tabs or after some time had passed. This indicates that the chat clear functionality was not properly persisting across browser sessions and user authentication state changes.

## Code changes

- **Added user-specific localStorage persistence**: Implemented user ID tracking and localStorage keys (`chatClearCutoff:${userId}`) to persist clear cutoff timestamps per user
- **Enhanced authentication state handling**: Added `supabase.auth.onAuthStateChange` listener to properly handle user session changes and restore clear cutoff state
- **Improved clear chat function**: Updated `handleClearChat` to save the cutoff timestamp to localStorage immediately when clearing, ensuring persistence across tabs and sessions
- **Added proper cleanup**: Implemented component unmounting cleanup and subscription management to prevent memory leaks
- **Code cleanup**: Removed unnecessary comments throughout the componentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/87710a066f1544568656bf3de19e1e52/pixel-nest)

👀 [Preview Link](https://87710a066f1544568656bf3de19e1e52-pixel-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>87710a066f1544568656bf3de19e1e52</projectId>-->
<!--<branchName>pixel-nest</branchName>-->